### PR TITLE
module names should use forward slash (/) instead of dash (-)

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -31,8 +31,8 @@
   ],
   "tags": [ "monitoring", "aws", "cloudwatch" ],
   "dependencies": [
-    {"name":"puppetlabs-stdlib","version_requirement":">= 1.0.0"},
-    {"name":"puppet-archive","version_requirement":"1.2.x"}
+    {"name":"puppetlabs/stdlib","version_requirement":">= 1.0.0"},
+    {"name":"puppet/archive","version_requirement":"1.2.x"}
   ],
   "data_provider": null
 }


### PR DESCRIPTION
Without this change, I get the following error when I use `puppet module list` (note that I **do** have the dependencies installed):
```
Warning: Missing dependency 'puppet-archive':
  'MasterRoot24-cloudwatch' (v0.3.1) requires 'puppet-archive' (v1.2.x)
Warning: Missing dependency 'puppetlabs-stdlib':
  'MasterRoot24-cloudwatch' (v0.3.1) requires 'puppetlabs-stdlib' (>= 1.0.0)
```

This is on Puppet 3.8 (EoL) and may not be an issue on supported version of Puppet. However, I don't see any downside to making the change.

The documentation doesn't require forward slashes, but only forward slashes are used in the examples:

- Puppet 5.3: [Specifying dependencies in modules - Module metadata and metadata.json](https://puppet.com/docs/puppet/5.3/modules_metadata.html#specifying-dependencies-in-modules).
- Puppet 4.10: [Specifying dependencies in modules - Module metadata and metadata.json](https://puppet.com/docs/puppet/4.10/modules_metadata.html#specifying-dependencies-in-modules).
- Puppet 3.8: [Specifying dependencies in modules - Publishing Modules on the Puppet Forge](https://docs.puppet.com/puppet/3.8/modules_publishing.html#dependencies-in-metadatajson)