### PR TITLE
updated to assign variables to cmd and then remove extra spaces for c…

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -276,10 +276,12 @@ class cloudwatch (
   }
 
   $pl_path = "${dest_dir}/mon-put-instance-data.pl"
-  $command = "${pl_path} ${mem_util} ${mem_used} ${mem_avail} ${swap_util}\
-              ${swap_used} ${memory_units_val} ${disk_path_val} ${disk_space_util_val}\
-              ${disk_space_used_val} ${disk_space_avail_val} ${disk_space_units_val}\
-              ${aggregated_val} ${auto_scaling_val} ${creds_path} --from-cron"
+  $cmd = "${pl_path} ${mem_util} ${mem_used} ${mem_avail} ${swap_util}\
+          ${swap_used} ${memory_units_val} ${disk_path_val}\
+          ${disk_space_util_val} ${disk_space_used_val}\
+          ${disk_space_avail_val} ${disk_space_units_val} ${aggregated_val}\
+          ${auto_scaling_val} ${creds_path} --from-cron"
+  $command = regsubst($cmd, ' +', ' ', 'G')
 
   # Setup a cron to push the metrics to Cloudwatch every minute
   cron { 'cloudwatch':


### PR DESCRIPTION
This pull request replaces all occurrences of multiples spaces in the cron job with a single space:
```
Notice: /Stage[main]/Cloudwatch/Cron[cloudwatch]/command:
current_value /opt/aws-scripts-mon/mon-put-instance-data.pl --mem-util --mem-used --mem-avail --swap-util              --swap-used --memory-units=megabytes --disk-path=/ --disk-path=/home --disk-space-util              --disk-space-used --disk-space-avail --disk-space-units=gigabytes                 --from-cron,
should be /opt/aws-scripts-mon/mon-put-instance-data.pl --mem-util --mem-used --mem-avail --swap-util --swap-used --memory-units=megabytes --disk-path=/ --disk-path=/home --disk-space-util --disk-space-used --disk-space-avail --disk-space-units=gigabytes --from-cron (noop)
```
(I added newlines to make it a little easier to read)