### PR TITLE
Add extra_args parameter for passing extra arguments to mon-put-instance-data.pl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## Unreleased
+* Add extra_args parameter for passing extra arguments to `mon-put-instance-data.pl`
+
 ## Release [0.5.2](https://github.com/JoeNyland/puppet-cloudwatch/releases/tag/0.5.2)
 
 * Use cron instead of cronie on Debian/Ubuntu OSes

--- a/README.md
+++ b/README.md
@@ -216,6 +216,12 @@ The script reports only Auto Scaling metrics.
 
 Default: `false`
 
+#### `extra_args`
+
+Add extra arguments string to the execution of `mon-put-instance-data.pl`.
+
+Default: empty string
+
 #### `cron_min`
 
 The minute at which to run the cron job, specified an cron format. e.g. `'*/5'` would push metrics to Cloudwatch

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -132,6 +132,7 @@ class cloudwatch (
   $aggregated_only         = false,
   $auto_scaling            = false,
   $auto_scaling_only       = false,
+  $extra_args              = '',
   $cron_min                = '*',
   $install_target          = '/opt',
   $manage_dependencies     = true,
@@ -280,7 +281,7 @@ class cloudwatch (
           --from-cron ${memory_units_val} ${disk_space_units_val} ${creds_path} ${credentials} ${iam_role_val}
           ${mem_util} ${mem_used} ${mem_avail} ${swap_util} ${swap_used}
           ${disk_path_val} ${disk_space_util_val} ${disk_space_used_val} ${disk_space_avail_val}
-          ${aggregated_val} ${auto_scaling_val}"
+          ${aggregated_val} ${auto_scaling_val} ${extra_args}"
 
   if ($manage_dependencies) {
     cron { 'cloudwatch':


### PR DESCRIPTION
We have a use case where we need to pass additional args to mon-put-instance-data.pl script, hence we're introducing a new `extra_args` parameter as part of this PR.

Example usage:
```
  class { '::cloudwatch':
      enable_mem_util         => true,
      enable_mem_used         => true,
      enable_mem_avail        => true,
      enable_disk_space_util  => true,
      enable_disk_space_used  => true,
      enable_disk_space_avail => true,
      enable_swap_util        => false,
      enable_swap_used        => false,
      auto_scaling            => $autoscaling,
      cron_min                => '*',
      disk_path               => $disk_path ,
      zip_url                 => 'https://somesite.com/our-custom-aws-scripts-mon-1.3.0.zip',
      extra_args              => '--proxy=http://some-proxy:3128'
    }
```